### PR TITLE
Add default rule for all clients (#1)

### DIFF
--- a/apps/vmq_diversity/priv/auth/mongodb.lua
+++ b/apps/vmq_diversity/priv/auth/mongodb.lua
@@ -65,19 +65,13 @@ require "auth/auth_commons"
 -- FOLLOWING SCRIPT.
 function auth_on_register(reg)
     if reg.username ~= nil and reg.password ~= nil then
-        doc = mongodb.find_one(pool, "vmq_acl_auth", 
-                                {mountpoint = reg.mountpoint,
-                                 client_id = reg.client_id,
-                                 username = reg.username})
+        local specific = { mountpoint = reg.mountpoint, client_id = reg.client_id, username = reg.username }
+        local default = { mountpoint = reg.mountpoint, client_id = '*', username = reg.username }
+        local doc = mongodb.find_one(pool, "vmq_acl_auth", specific) or mongodb.find_one(pool, "vmq_acl_auth", default)
+
         if doc ~= false then
             if doc.passhash == bcrypt.hashpw(reg.password, doc.passhash) then
-                cache_insert(
-                    reg.mountpoint, 
-                    reg.client_id, 
-                    reg.username,
-                    doc.publish_acl,
-                    doc.subscribe_acl
-                    )
+                cache_insert(reg.mountpoint, reg.client_id, reg.username, doc.publish_acl, doc.subscribe_acl)
                 return true
             end
         end

--- a/apps/vmq_diversity/priv/auth/mysql.lua
+++ b/apps/vmq_diversity/priv/auth/mysql.lua
@@ -55,36 +55,42 @@ require "auth/auth_commons"
 -- 
 -- IF YOU USE THE SCHEMA PROVIDED ABOVE NOTHING HAS TO BE CHANGED IN THE
 -- FOLLOWING SCRIPT.
+function validate_result_server_side(results, reg)
+    if #results > 0 then
+        local targetRow
+        --   search for a specific rule for the client client_id
+        for _, row in ipairs(results) do
+            if row.client_id ~= '*' then
+                targetRow = row
+                break
+            end
+        end
+
+        -- no specific rule, get default rule for all clients
+        if targetRow == nil then
+            targetRow = results[1]
+        end
+
+        local publish_acl = json.decode(targetRow.publish_acl)
+        local subscribe_acl = json.decode(targetRow.subscribe_acl)
+        cache_insert(reg.mountpoint, reg.client_id, reg.username, publish_acl, subscribe_acl)
+        return true
+    end
+    return false
+end
+
 function auth_on_register(reg)
     if reg.username ~= nil and reg.password ~= nil then
-        results = mysql.execute(pool,
-            [[SELECT publish_acl, subscribe_acl
+        local results = mysql.execute(pool, [[SELECT publish_acl, subscribe_acl, client_id
               FROM vmq_auth_acl
               WHERE
                 mountpoint=? AND
-                client_id=? AND
+                (client_id=? OR client_id='*') AND
                 username=? AND
-                password=]]..mysql.hash_method(),
-            reg.mountpoint,
-            reg.client_id,
-            reg.username,
-            reg.password)
-        if #results == 1 then
-            row = results[1]
-            publish_acl = json.decode(row.publish_acl)
-            subscribe_acl = json.decode(row.subscribe_acl)
-            cache_insert(
-                reg.mountpoint, 
-                reg.client_id, 
-                reg.username,
-                publish_acl,
-                subscribe_acl
-                )
-            return true
-        else
-            return false
-        end
+                password=]] .. mysql.hash_method(), reg.mountpoint, reg.client_id, reg.username, reg.password)
+        return validate_result_server_side(results, reg)
     end
+    return false
 end
 
 pool = "auth_mysql"


### PR DESCRIPTION
* Add a default rule for all clients

If there is no specific rule for a client id search for client id '*'. This rule will match all the clients only and only if there is no specific rule for that client id.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CODE_OF_CONDUCT.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
